### PR TITLE
Updated wepack-dev-server to @3.1.10 for security reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "babel-preset-stage-0": "^6.24.1",
     "webpack": "^4.16.1",
     "webpack-cli": "^3.0.8",
-    "webpack-dev-server": "^3.1.4"
+    "webpack-dev-server": "^3.1.10"
   }
 }


### PR DESCRIPTION
# Just and update to the webpack-dev-server
When I ran `npm install` everything does install and work fine, but I received a **security warning**
that there were _**3 high severity vulnerabilities**_ from the `npm-cli`
I ran `npm audit fix` and this was the result. 👍 
I'm running `npm v.6.4.0` along with Node 10.13 on Windows 10

I figured _why not update it??_
I don't want newer coders to get confused by the warnings 

Thanks Brad your the best man 🥇 😎 🔥 🔥 
Love your YouTube channel and the Udemy courses 

## Screenshot
![2018-11-17](https://user-images.githubusercontent.com/26460352/48679158-a0133f00-eb5a-11e8-9c0e-26676ccdab89.png)

