### PR TITLE
Upgrade to Babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "author": "Brad Traversy",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.5",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-stage-0": "^6.24.1",
+    "@babel/core": "^7.4.3",
+    "babel-loader": "^8.0.5",
+    "@babel/polyfill": "^7.4.3",
+    "@babel/preset-env": "^7.4.3",
+    "@babel/preset-stage-0": "^7.0.0",
     "webpack": "^4.16.1",
     "webpack-cli": "^3.0.8",
     "webpack-dev-server": "^3.1.10"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   entry: {
     app: [
-      'babel-polyfill',
+      '@babel/polyfill',
       './src/app.js',
     ],
   },
@@ -17,7 +17,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel-loader',
         query: {
-           presets: ['env', 'stage-0']
+           presets: ['@babel/preset-env', '@babel/preset-stage-0']
         }
     }]
   }


### PR DESCRIPTION
Upgrade packages and presets to Babel 7 in both the `package.json` and the `webpack.config.js` files.

`babel-core` => `@babel/core`
`babel-loader` => `babel-loader`
`babel-polyfill` => `@babel/polyfill`
`babel-preset-env` => `@babel/preset-env`
`babel-preset-stage-0`  => `@babel/preset-stage-0`